### PR TITLE
Add chained transaction to burn fake token

### DIFF
--- a/src/main/scala-2.12/org/ergoplatform/dex/commands/CancelOrderCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/dex/commands/CancelOrderCmd.scala
@@ -194,8 +194,11 @@ object CancelOrder {
     val outbox = OutBoxProto(outboxValue, Seq(), Some(mintTokenInfo), Seq(), outboxContract)
     val inputBoxes = selectInputBoxes(orderBox, outboxValue + txFee, unspentBoxesForAmount)
     // TODO add second tx burning the minted token
-    Seq(TxProto(inputBoxes, Seq(outbox), txFee, recipientAddress))
+    val firstTx = TxProto(inputBoxes, Seq(outbox), txFee, recipientAddress)
+    Seq(firstTx)
   }
+
+  def burnMintedTokenTx(txId: String, recipientAddress: Address, unspentBoxesForAmount: (Long) => Seq[InputBox]): TxProto = ???
 
   def selectInputBoxes(orderBox: InputBox, outboxValue: Long,
                        unspentBoxesForAmount: (Long) => Seq[InputBox]): Seq[InputBox] =

--- a/src/main/scala-2.12/org/ergoplatform/dex/commands/CancelOrderCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/dex/commands/CancelOrderCmd.scala
@@ -73,7 +73,8 @@ case class CancelOrderCmd(toolConf: ErgoToolConfig,
           senderProver.sign(firstTx)
         }
         console.println(s"Tx: ${signedFirstTx.toJson(true)}")
-        val secondTx = CancelOrder.txToBurnMintedToken(signedFirstTx, recipientAddress).toTx(txBuilder)
+        val inputBoxWithToken = signedFirstTx.getOutputsToSpend().get(0)
+        val secondTx = CancelOrder.txToBurnMintedToken(inputBoxWithToken, recipientAddress).toTx(txBuilder)
         val signedSecondTx = loggedStep(s"Signing the second cancel transaction for buy order", console) {
           senderProver.sign(secondTx)
         }
@@ -201,8 +202,7 @@ object CancelOrder {
     TxProto(inputBoxes, Seq(outbox), txFee, recipientAddress)
   }
 
-  def txToBurnMintedToken(firstTx: SignedTransaction, recipientAddress: Address): TxProto = {
-    val inputBoxWithToken = firstTx.getOutputsToSpend().get(0)
+  def txToBurnMintedToken(inputBoxWithToken: InputBox, recipientAddress: Address): TxProto = {
     val txFee = MinFee
     val outboxValue = MinFee
     val outboxContract = new ErgoTreeContract(SigmaPropConstant(recipientAddress.getPublicKey))

--- a/src/main/scala-2.12/org/ergoplatform/dex/commands/CancelOrderCmd.scala
+++ b/src/main/scala-2.12/org/ergoplatform/dex/commands/CancelOrderCmd.scala
@@ -193,6 +193,7 @@ object CancelOrder {
     val outboxValue = orderBox.getValue - txFee
     val outbox = OutBoxProto(outboxValue, Seq(), Some(mintTokenInfo), Seq(), outboxContract)
     val inputBoxes = selectInputBoxes(orderBox, outboxValue + txFee, unspentBoxesForAmount)
+    // TODO add second tx burning the minted token
     Seq(TxProto(inputBoxes, Seq(outbox), txFee, recipientAddress))
   }
 

--- a/src/test/scala/org/ergoplatform/dex/ErgoDexToolSpec.scala
+++ b/src/test/scala/org/ergoplatform/dex/ErgoDexToolSpec.scala
@@ -379,6 +379,7 @@ class ErgoDexToolSpec
            |""".stripMargin, data)
     println(res)
     res should include ("\"transactionId\": \"3acd12f5a85cfeba4096d2d5a562ac3f44ee2bb7e3ba4861b1d85d2f01eac048\",")
+    res should include ("\"transactionId\": \"secondTx\",")
   }
 
   property("dex:ListMyOrders command") {

--- a/src/test/scala/org/ergoplatform/dex/commands/CancelOrderSpec.scala
+++ b/src/test/scala/org/ergoplatform/dex/commands/CancelOrderSpec.scala
@@ -68,29 +68,25 @@ class CancelOrderSpec extends PropSpec
       val firstTx = txProtos(0)
       val secondTx = txProtos(1)
 
-      firstTx.sendChangeTo shouldEqual orderAuthorAddress
       firstTx.outputBoxes.length shouldBe 1
+      val expectedOutboxContract = sendToPk(orderAuthorAddress)
+      firstTx.outputBoxes.head.contract.getErgoTree shouldEqual expectedOutboxContract.getErgoTree
+      firstTx.sendChangeTo shouldEqual orderAuthorAddress
       firstTx.outputBoxes.head.getValue shouldBe (orderBox.getValue - MinFee)
+      // although in this case minted token should be empty
+      // as a workaround for https://github.com/ScorexFoundation/sigmastate-interpreter/issues/628
       firstTx.outputBoxes.head.mintToken.isDefined shouldBe true
+      val mintedToken = firstTx.outputBoxes.head.mintToken.get.token
       firstTx.outputBoxes.head.tokens shouldBe empty
 
       secondTx.sendChangeTo shouldEqual orderAuthorAddress
       // TODO check that minted token from previous tx is present in inputs
       secondTx.outputBoxes.length shouldBe 1
+      secondTx.outputBoxes.head.contract.getErgoTree shouldEqual expectedOutboxContract.getErgoTree
       secondTx.outputBoxes.head.getValue shouldBe (MinFee)
-      // TODO check that minted token from previous tx is NOT present in outputs
+      // check that minted token from previous tx is NOT present in outputs
+      secondTx.outputBoxes.forall(!_.tokens.exists(_.equals(mintedToken)))
       secondTx.outputBoxes.head.mintToken.isDefined shouldBe false
-
-      // txProto.outputBoxes.length shouldBe 1
-      // val outbox = txProto.outputBoxes.head
-      // outbox.getValue shouldBe orderBox.getValue - MinFee
-
-      // although in this case outbox.tokes should be empty
-      // as a workaround for https://github.com/ScorexFoundation/sigmastate-interpreter/issues/628
-      // box.tokens cannot be empty
-
-      // val expectedOutboxContract = sendToPk(orderAuthorAddress)
-      // outbox.contract.getErgoTree shouldEqual expectedOutboxContract.getErgoTree
     }
   }
 


### PR DESCRIPTION
Close #11 

Todo: 
- [x] figure out a way use output box from the minting token tx as input box for the second tx;
- [x] rebase onto develop after #14 is merged;
- [ ] implement token burning support in tx building (wallet);